### PR TITLE
 Remove triton optimization config, causing error for multi gpu infer…

### DIFF
--- a/models/triton-model-repo/sid-minibert-onnx/config.pbtxt
+++ b/models/triton-model-repo/sid-minibert-onnx/config.pbtxt
@@ -27,11 +27,3 @@ dynamic_batching {
   preferred_batch_size: [ 1, 4, 8, 16, 32 ]
   max_queue_delay_microseconds: 50000
 }
-
-optimization { execution_accelerators {
-  gpu_execution_accelerator : [ {
-    name : "tensorrt"
-    parameters { key: "precision_mode" value: "FP16" }
-    parameters { key: "max_workspace_size_bytes" value: "1073741824" }
-    }]
-}}


### PR DESCRIPTION
This fixes error caused when running Triton inference for multi-GPU for SID pipeline. 
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Closes 
When running Triton inference for SID pipeline using multi-gpu.  It result on segment fault. 
`2024-12-09 23:24:38.378753895 [E:onnxruntime:, sequential_executor.cc:516 ExecuteKernel] Non-zero status code returned while running TRTKernel_graph_torch_jit_3139280210422962738_0 node. Name:'TensorrtExecutionProvider_TRTKernel_graph_torch_jit_3139280210422962738_0_0' Status Message: TensorRT EP execution context enqueue failed.`
## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
